### PR TITLE
Add cache deletion for rate limit exceeded key

### DIFF
--- a/src/Guardian.php
+++ b/src/Guardian.php
@@ -308,6 +308,8 @@ class Guardian
             }
         }
 
+        $keysToDelete[] = $this->getRateLimitExceededCacheKey();
+
         $allDeleted = true;
         foreach ($keysToDelete as $key) {
             if (!$this->cache->forget($key)) {

--- a/tests/GuardianTest.php
+++ b/tests/GuardianTest.php
@@ -187,6 +187,7 @@ it('returns false if not each key is cleared from the cache', function () {
     $cache->shouldReceive('forget')->with('guardian_test:rate_limit_5_per_minute')->andReturn(false);
     $cache->shouldReceive('forget')->with('guardian_test:rate_limit_500_per_hour')->andReturn(true);
     $cache->shouldReceive('forget')->with('guardian_test:error:2_minute_1_no_expiry')->andReturn(true);
+    $cache->shouldReceive('forget')->with('guardian_test:rate_limit_exceeded')->andReturn(false);
 
     $guardian = new Guardian('test', $cache, $rules, $errorRules);
 


### PR DESCRIPTION
Updated Guardian and GuardianTest to ensure the cache key for rate limits exceeded is deleted on clearCache. This change ensures consistency and thorough cache cleanup to better handle rate limiting cases.